### PR TITLE
Updated GKE cluster location from GKE_ZONE to GKE_REGION

### DIFF
--- a/.github/workflows/google.yml
+++ b/.github/workflows/google.yml
@@ -78,7 +78,7 @@ jobs:
       uses: google-github-actions/get-gke-credentials@v1
       with:
         cluster_name: ${{ env.GKE_CLUSTER }}
-        location: ${{ env.GKE_ZONE }}
+        location: ${{ env.GKE_REGION }}
 
     # The KUBECONFIG env var is automatically exported and picked up by kubectl.
     - id: 'get-pods'


### PR DESCRIPTION
This GKE cluster is of AutoPilot which chooses Zone itself. REGION is fixed in it but not ZONE. 

If you create Standard cluster, you can choose specific ZONEs and configure them